### PR TITLE
Use newest Pillow methods if 9.2.0 is installed

### DIFF
--- a/pilmoji/core.py
+++ b/pilmoji/core.py
@@ -287,7 +287,7 @@ class Pilmoji:
 
             for node in line:
                 content = node.content
-                width, height = font.getsize(content)
+                width, height = font.getlength(content)
 
                 if node.type is NodeType.text:
                     self.draw.text((x, y), content, *args, **kwargs)
@@ -309,7 +309,7 @@ class Pilmoji:
                 with Image.open(stream).convert('RGBA') as asset:
                     width = int(emoji_scale_factor * font.size)
                     size = width, math.ceil(asset.height / asset.width * width)
-                    asset = asset.resize(size, Image.ANTIALIAS)
+                    asset = asset.resize(size, Image.Resampling.LANCZOS)
 
                     ox, oy = emoji_position_offset
                     self.image.paste(asset, (x + ox, y + oy), asset)

--- a/pilmoji/core.py
+++ b/pilmoji/core.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import math
 
+import PIL
 from PIL import Image, ImageDraw, ImageFont
+
 from typing import Dict, Optional, SupportsInt, TYPE_CHECKING, Tuple, Type, TypeVar, Union
 
 from .helpers import NodeType, getsize, to_nodes
@@ -287,7 +289,11 @@ class Pilmoji:
 
             for node in line:
                 content = node.content
-                width = font.getlength(content)
+
+                if PIL.__version__ >= "9.2.0":
+                    width = font.getlength(content)
+                else:
+                    width, _ = font.getsize(content)
 
                 if node.type is NodeType.text:
                     self.draw.text((x, y), content, *args, **kwargs)
@@ -309,7 +315,7 @@ class Pilmoji:
                 with Image.open(stream).convert('RGBA') as asset:
                     width = int(emoji_scale_factor * font.size)
                     size = width, math.ceil(asset.height / asset.width * width)
-                    asset = asset.resize(size, Image.Resampling.LANCZOS)
+                    asset = asset.resize(size, Image.LANCZOS)
 
                     ox, oy = emoji_position_offset
                     self.image.paste(asset, (x + ox, y + oy), asset)

--- a/pilmoji/core.py
+++ b/pilmoji/core.py
@@ -315,7 +315,7 @@ class Pilmoji:
                 with Image.open(stream).convert('RGBA') as asset:
                     width = int(emoji_scale_factor * font.size)
                     size = width, math.ceil(asset.height / asset.width * width)
-                    asset = asset.resize(size, Image.LANCZOS)
+                    asset = asset.resize(size, Image.Resampling.LANCZOS)
 
                     ox, oy = emoji_position_offset
                     self.image.paste(asset, (x + ox, y + oy), asset)

--- a/pilmoji/core.py
+++ b/pilmoji/core.py
@@ -250,7 +250,7 @@ class Pilmoji:
             The rescaling factor for emojis. This can be used for fine adjustments.
             Defaults to the factor given in the class constructor, or `1`.
         emoji_position_offset: Tuple[int, int]
-            The emoji position offset for emojis. The can be used for fine adjustments.
+            The emoji position offset for emojis. Then can be used for fine adjustments.
             Defaults to the offset given in the class constructor, or `(0, 0)`.
         """
 
@@ -287,7 +287,7 @@ class Pilmoji:
 
             for node in line:
                 content = node.content
-                width, height = font.getlength(content)
+                width = font.getlength(content)
 
                 if node.type is NodeType.text:
                     self.draw.text((x, y), content, *args, **kwargs)

--- a/pilmoji/core.py
+++ b/pilmoji/core.py
@@ -252,7 +252,7 @@ class Pilmoji:
             The rescaling factor for emojis. This can be used for fine adjustments.
             Defaults to the factor given in the class constructor, or `1`.
         emoji_position_offset: Tuple[int, int]
-            The emoji position offset for emojis. Then can be used for fine adjustments.
+            The emoji position offset for emojis. This can be used for fine adjustments.
             Defaults to the offset given in the class constructor, or `(0, 0)`.
         """
 

--- a/pilmoji/core.py
+++ b/pilmoji/core.py
@@ -291,7 +291,7 @@ class Pilmoji:
                 content = node.content
 
                 if PIL.__version__ >= "9.2.0":
-                    width = font.getlength(content)
+                    width = int(font.getlength(content))
                 else:
                     width, _ = font.getsize(content)
 

--- a/pilmoji/core.py
+++ b/pilmoji/core.py
@@ -77,11 +77,11 @@ class Pilmoji:
 
         self.source: BaseSource = source
 
-        self._cache: bool = bool(cache)
+        self._cache: bool = cache
         self._closed: bool = False
         self._new_draw: bool = False
 
-        self._render_discord_emoji: bool = bool(render_discord_emoji)
+        self._render_discord_emoji: bool = render_discord_emoji
         self._default_emoji_scale_factor: float = emoji_scale_factor
         self._default_emoji_position_offset: Tuple[int, int] = emoji_position_offset
 

--- a/pilmoji/helpers.py
+++ b/pilmoji/helpers.py
@@ -9,7 +9,7 @@ from emoji import unicode_codes
 import PIL
 from PIL import ImageFont
 
-from typing import Dict, Final, List, NamedTuple, TYPE_CHECKING
+from typing import Dict, Final, List, NamedTuple, TYPE_CHECKING, Tuple
 
 if TYPE_CHECKING:
     from .core import FontT
@@ -146,11 +146,10 @@ def getsize(
 
             if node.type is not NodeType.text:
                 width = int(emoji_scale_factor * font.size)
+            elif PIL.__version__ >= "9.2.0":
+                width = font.getlength(content)
             else:
-                if PIL.__version__ >= "9.2.0":
-                    width = font.getlength(content)
-                else:
-                    width, _ = font.getsize(content)
+                width, _ = font.getsize(content)
 
             this_x += width
 

--- a/pilmoji/helpers.py
+++ b/pilmoji/helpers.py
@@ -147,7 +147,7 @@ def getsize(
             if node.type is not NodeType.text:
                 width = int(emoji_scale_factor * font.size)
             elif PIL.__version__ >= "9.2.0":
-                width = font.getlength(content)
+                width = int(font.getlength(content))
             else:
                 width, _ = font.getsize(content)
 

--- a/pilmoji/helpers.py
+++ b/pilmoji/helpers.py
@@ -145,7 +145,7 @@ def getsize(
             if node.type is not NodeType.text:
                 width = int(emoji_scale_factor * font.size)
             else:
-                width, _ = font.getsize(content)
+                width, _ = font.getlength(content)
 
             this_x += width
 

--- a/pilmoji/helpers.py
+++ b/pilmoji/helpers.py
@@ -5,6 +5,8 @@ import re
 from enum import Enum
 
 from emoji import unicode_codes
+
+import PIL
 from PIL import ImageFont
 
 from typing import Dict, Final, List, NamedTuple, TYPE_CHECKING
@@ -145,7 +147,10 @@ def getsize(
             if node.type is not NodeType.text:
                 width = int(emoji_scale_factor * font.size)
             else:
-                width = font.getlength(content)
+                if PIL.__version__ >= "9.2.0":
+                    width = font.getlength(content)
+                else:
+                    width, _ = font.getsize(content)
 
             this_x += width
 

--- a/pilmoji/helpers.py
+++ b/pilmoji/helpers.py
@@ -145,7 +145,7 @@ def getsize(
             if node.type is not NodeType.text:
                 width = int(emoji_scale_factor * font.size)
             else:
-                width, _ = font.getlength(content)
+                width = font.getlength(content)
 
             this_x += width
 


### PR DESCRIPTION
DeprecationWarning: LANCZOS is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.LANCZOS instead.
Although it is not typehinted yet, `Image.Resampling.LANCZOS` needs to be used instead of `Image.LANCZOS` to avoid warning logs.

if pillow 9.2.0 or greater installed, use getlength, otherwise use getsize