### PR TITLE
`node_spacing` parameter for .text() similar to `spacing`, for number of pixels between nodes

### DIFF
--- a/pilmoji/core.py
+++ b/pilmoji/core.py
@@ -75,11 +75,11 @@ class Pilmoji:
 
         self.source: BaseSource = source
 
-        self._cache: bool = bool(cache)
+        self._cache: bool = cache
         self._closed: bool = False
         self._new_draw: bool = False
 
-        self._render_discord_emoji: bool = bool(render_discord_emoji)
+        self._render_discord_emoji: bool = render_discord_emoji
         self._default_emoji_scale_factor: float = emoji_scale_factor
         self._default_emoji_position_offset: Tuple[int, int] = emoji_position_offset
 

--- a/pilmoji/core.py
+++ b/pilmoji/core.py
@@ -210,6 +210,7 @@ class Pilmoji:
         font: FontT = None,
         anchor: str = None,
         spacing: int = 4,
+        node_spacing: int = 0,
         align: str = "left",
         direction: str = None,
         features: str = None,
@@ -246,6 +247,8 @@ class Pilmoji:
             The font to render the text with.
         spacing: int
             How many pixels there should be between lines. Defaults to `4`
+        node_spacing: int
+            How many pixels there should be between nodes (text/unicode_emojis/custom_emojis). Defaults to `0`
         emoji_scale_factor: float
             The rescaling factor for emojis. This can be used for fine adjustments.
             Defaults to the factor given in the class constructor, or `1`.
@@ -291,7 +294,7 @@ class Pilmoji:
 
                 if node.type is NodeType.text:
                     self.draw.text((x, y), content, *args, **kwargs)
-                    x += width
+                    x += node_spacing + width
                     continue
 
                 stream = None
@@ -303,7 +306,7 @@ class Pilmoji:
 
                 if not stream:
                     self.draw.text((x, y), content, *args, **kwargs)
-                    x += width
+                    x += node_spacing + width
                     continue
 
                 with Image.open(stream).convert('RGBA') as asset:
@@ -314,7 +317,7 @@ class Pilmoji:
                     ox, oy = emoji_position_offset
                     self.image.paste(asset, (x + ox, y + oy), asset)
 
-                x += width
+                x += node_spacing + width
             y += spacing + font.size
 
     def __enter__(self: P) -> P:


### PR DESCRIPTION
This pull request adds an additional parameter to Pilmoji.text() that lets you specify the spacing between each node. This can come in handy as illustrated by the following example:

## Before
Without the `node_spacing` parameter, you would have no choice but to accept this ugly spacing between each node (emoji in this case) on each line. You can pass in a negative value in the `spacing` parameter to deal with the line spacing, but there is no way to do that for between nodes
![image](https://user-images.githubusercontent.com/81734495/236741417-6cbdb85c-0b6a-4036-b485-8147f27d3991.png)

## After
With the `node_spacing` parameter, you can pass in a negative value to deal with the spacing between nodes, and have smooth emoji arrays!
![image](https://user-images.githubusercontent.com/81734495/236741717-be081ceb-affc-4599-b126-170821f69eba.png)


Note: I initially renamed `spacing` parameter to `line_spacing` to properly distinguish them, but that would be a breaking change and I'm not sure how you'd feel about that so I leave that up to you if you deem fit!
