### PR TITLE
Add option to cache fetched emoji to disk for big speedup

### DIFF
--- a/pilmoji/core.py
+++ b/pilmoji/core.py
@@ -50,6 +50,9 @@ class Pilmoji:
     emoji_position_offset: Tuple[int, int]
         A 2-tuple representing the x and y offset for emojis when rendering,
         respectively. Defaults to `(0, 0)`
+    disk_cache: bool
+        Whether or not to permanently cache cdn-fetched emojis to disk,
+        defaults to `False` but can greatly improve speed in certain cases.
     """
 
     def __init__(
@@ -61,7 +64,8 @@ class Pilmoji:
         draw: Optional[ImageDraw.ImageDraw] = None,
         render_discord_emoji: bool = True,
         emoji_scale_factor: float = 1.0,
-        emoji_position_offset: Tuple[int, int] = (0, 0)
+        emoji_position_offset: Tuple[int, int] = (0, 0),
+        disk_cache: bool = False,
     ) -> None:
         self.image: Image.Image = image
         self.draw: ImageDraw.ImageDraw = draw
@@ -70,7 +74,7 @@ class Pilmoji:
             if not issubclass(source, BaseSource):
                 raise TypeError(f'source must inherit from BaseSource, not {source}.')
 
-            source = source()
+            source = source(disk_cache=disk_cache)
 
         elif not isinstance(source, BaseSource):
             raise TypeError(f'source must inherit from BaseSource, not {source.__class__}.')


### PR DESCRIPTION
This PR adds an option to cache fetched emojis to disk. For my use case this provides a massive boost to performance.  

To demonstrate the speed up, I called Pilmoji three times, the first time with disk_cache = False, the next two times with disk_cache=True. Here are the results:

```
Block 1 duration: 1.4033 seconds
Block 2 duration: 1.3994 seconds
Block 3 duration: 0.0041 seconds
```

The first two calls are roughly equivalent, but the third call benefits from the emojis already having been fetched and stored to disk locally. 

And here's the speed test code:

```python
import time
from pilmoji import Pilmoji
from PIL import Image

test_image = Image.new("RGBA", (1080, 1920), (255, 255, 255, 0))
x = 100
y = 100
text_color = (255, 255, 255)
line = "⏱️⏳🏎️🐇🐢💨🚀⏩"

# Block 1
start_time = time.time()
with Pilmoji(test_image) as pilmoji:
    pilmoji.text((x, y), line, text_color)
end_time = time.time()
print(f"Block 1 duration: {end_time - start_time:.4f} seconds")

# Block 2
start_time = time.time()
with Pilmoji(test_image, disk_cache=True) as pilmoji:
    pilmoji.text((x, y), line, text_color)
end_time = time.time()
print(f"Block 2 duration: {end_time - start_time:.4f} seconds")

# Block 3
start_time = time.time()
with Pilmoji(test_image, disk_cache=True) as pilmoji:
    pilmoji.text((x, y), line, text_color)
end_time = time.time()
print(f"Block 3 duration: {end_time - start_time:.4f} seconds")
```

This speed-up made it possible to use Pilmoji for my use case, so I hope it can help others too!