### PR TITLE
Remove Deprecated Internal Function Usage in Emoji Language Pack Initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+this is a fix of the repo: https://github.com/jay3332/pilmoji which is not up to date
+
 # Pilmoji
 Pilmoji is an emoji renderer for [Pillow](https://github.com/python-pillow/Pillow/), 
 Python's imaging library.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-this is a fix of the repo: https://github.com/jay3332/pilmoji which is not up to date
-
 # Pilmoji
 Pilmoji is an emoji renderer for [Pillow](https://github.com/python-pillow/Pillow/), 
 Python's imaging library.

--- a/pilmoji/helpers.py
+++ b/pilmoji/helpers.py
@@ -15,7 +15,13 @@ if TYPE_CHECKING:
     from .core import FontT
 
 # This is actually way faster than it seems
-language_pack: Dict[str, str] = {data['en']: emj for emj, data in emoji.EMOJI_DATA.items() if 'en' in data and data['status'] <= emoji.STATUS['fully_qualified']}
+# Create a dictionary mapping English emoji descriptions to their unicode representations
+# Only include emojis that have an English description and are fully qualified
+language_pack: Dict[str, str] = {
+    data['en']: emj
+    for emj, data in emoji.EMOJI_DATA.items()
+    if 'en' in data and data['status'] <= emoji.STATUS['fully_qualified']
+}
 _UNICODE_EMOJI_REGEX = '|'.join(map(re.escape, sorted(language_pack.values(), key=len, reverse=True)))
 _DISCORD_EMOJI_REGEX = '<a?:[a-zA-Z0-9_]{1,32}:[0-9]{17,22}>'
 

--- a/pilmoji/helpers.py
+++ b/pilmoji/helpers.py
@@ -4,7 +4,7 @@ import re
 
 from enum import Enum
 
-from emoji import unicode_codes
+import emoji
 
 import PIL
 from PIL import ImageFont

--- a/pilmoji/helpers.py
+++ b/pilmoji/helpers.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from .core import FontT
 
 # This is actually way faster than it seems
-language_pack: Dict[str, str] = unicode_codes.get_emoji_unicode_dict('en')
+language_pack: Dict[str, str] = {data['en']: emj for emj, data in emoji.EMOJI_DATA.items() if 'en' in data and data['status'] <= emoji.STATUS['fully_qualified']}
 _UNICODE_EMOJI_REGEX = '|'.join(map(re.escape, sorted(language_pack.values(), key=len, reverse=True)))
 _DISCORD_EMOJI_REGEX = '<a?:[a-zA-Z0-9_]{1,32}:[0-9]{17,22}>'
 


### PR DESCRIPTION
This pull request fixes the initialization of the language_pack dictionary by removing the use of the deprecated internal function get_emoji_unicode_dict('en'), which is no longer available in the latest version of the emoji library.

Changes:
Replaced get_emoji_unicode_dict('en') with a dictionary comprehension that constructs language_pack directly from emoji.EMOJI_DATA.
The new implementation maps English emoji names to their Unicode representations, ensuring compatibility with the latest emoji library version.