### PR TITLE
Fix: ensure stroke is applied to all lines in multiline text with emojis

### DIFF
--- a/pilmoji/core.py
+++ b/pilmoji/core.py
@@ -415,7 +415,6 @@ class Pilmoji:
 
                 if stroke_ink is not None:
                     ink = stroke_ink
-                    stroke_width = 0
                 try:
                     _, offset = font.getmask2(
                         nodes_line_to_print[node_id],
@@ -423,7 +422,6 @@ class Pilmoji:
                         direction=direction,
                         features=features,
                         language=language,
-                        stroke_width=stroke_width,
                         anchor=anchor,
                         ink=ink,
                         start=start,


### PR DESCRIPTION
In the original implementation, there was logic that set  `stroke_width` to 0 during the text rendering process in the getmask2 function call. This caused subsequent lines of text to lose their stroke, as the stroke width was effectively disabled after the first line.

The fix involved removing the part where stroke_width was set to 0 after the stroke was applied. By doing this, the stroke_width parameter is preserved across all lines of the multiline text, ensuring that each line has its proper stroke.

Additionally, the `stroke_width` argument was removed from the `getmask2` call. This ensures that the stroke is applied consistently throughout all iterations when rendering the text. Instead of resetting the stroke for each line, the value of stroke_width remains intact, allowing the stroke to be applied uniformly to each line of text, including those that come after the first line.

This change ensures that the stroke is not lost when processing multiple lines of text, which was the core issue when rendering multiline text with emojis.


## Summary by Sourcery

Bug Fixes:
- Fix stroke application to ensure it is applied to all lines in multiline text with emojis by not setting stroke_width to 0.